### PR TITLE
[DVPS-358] Introducing newrelic custom events on deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.12
+
+RUN apk add --no-cache curl jq
+
+COPY ./scripts/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -12,8 +12,8 @@ inputs:
   insightsInsertKey:
     description: 'Your New Relic Insights Insert Key.'
     required: true
-  newrelicUrl:
-    description: 'New Relic URL containing your accountID.'
+  newrelicAccountId:
+    description: 'New Relic Account ID.'
     required: true
 runs:
   using: 'docker'
@@ -25,4 +25,4 @@ runs:
     ACTOR: ${{ github.actor }}
     PROJECT: ${{ github.repository }}
     NEW_RELIC_INGIGHTS_INSERT_KEY: ${{ inputs.insightsInsertKey }}
-    NEWRELIC_URL: ${{ inputs.newrelicUrl }}
+    NEWRELIC_ACCOUNT_ID: ${{ inputs.newrelicAccountId }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,28 @@
+name: 'New Relic Custom Event Action'
+author: 'Pier Digital Services'
+description: 'Send custom events to New Relic'
+branding:
+  icon: 'upload-cloud'
+  color: 'blue'
+inputs:
+  eventType:
+    description: 'Event Type inside New Relic. This will be used to query this data later.'
+    required: false
+    default: 'deploy'
+  insightsInsertKey:
+    description: 'Your New Relic Insights Insert Key.'
+    required: true
+  newrelicUrl:
+    description: 'New Relic URL containing your accountID.'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    EVENT_TYPE: ${{ inputs.eventType }}
+    DEPLOYMENT_STATUS: ${{ job.status }}
+    DESCRIPTION: ${{ github.event.commits[0].message }}
+    ACTOR: ${{ github.actor }}
+    PROJECT: ${{ github.repository }}
+    NEW_RELIC_INGIGHTS_INSERT_KEY: ${{ inputs.insightsInsertKey }}
+    NEWRELIC_URL: ${{ inputs.newrelicUrl }}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+json=$( jq -n \
+                --arg et "$EVENT_TYPE" \
+                --arg st "$DEPLOYMENT_STATUS" \
+                --arg dc "$DESCRIPTION" \
+                --arg ac "$ACTOR" \
+                --arg pj "$PROJECT" \
+                '{eventType: $et, status: $st, description: $dc, actor: $ac, project: $pj }' )
+
+echo "$json" | gzip -c | curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Insert-Key: $NEW_RELIC_INGIGHTS_INSERT_KEY" \
+    -H "Content-Encoding: gzip" \
+    --data-binary @- \
+    "$NEWRELIC_URL"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,4 +13,4 @@ echo "$json" | gzip -c | curl -X POST \
     -H "X-Insert-Key: $NEW_RELIC_INGIGHTS_INSERT_KEY" \
     -H "Content-Encoding: gzip" \
     --data-binary @- \
-    "$NEWRELIC_URL"
+    "https://insights-collector.newrelic.com/v1/accounts/$NEWRELIC_ACCOUNT_ID/events"


### PR DESCRIPTION
Send custom events to New Relic based on job status and other contextual information

This information can be used to create dashboards and alerts inside New Relic based on the event type

P.S: README will be updated later
